### PR TITLE
Add Rust implementation of folder hash tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "folderhash"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1"
+blake2 = "0.10"
+blake3 = "1"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha1 = "0.10"
+sha2 = "0.10"
+walkdir = "2"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
+hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# FolderHash
+
+FolderHash is a command line utility written in Rust that scans a directory
+recursively and computes checksums for every file.  Results can be printed to
+the console or stored in a list file.  Existing entries are skipped so the
+operation can be resumed later.  The tool can also verify a directory against a
+previously generated checksum list.
+
+By default the program uses the SHA1 hash algorithm but the algorithm can be
+changed using the `--hash` flag.  Supported values include `sha1`, `sha256`,
+`blake2b`, `blake3`, `xxhash`, `xxh3` and `xxh128`.
+
+## Usage
+
+Generate checksums and write them to a file:
+
+```
+folderhash --dir /path/to/dir --list hashes.txt
+```
+
+Verify files against an existing list:
+
+```
+folderhash --verify --dir /path/to/dir --list hashes.txt
+```
+
+Use `--progress` to display progress information and `--json` to read/write
+lists in JSON Lines format.
+
+## License
+
+This project is licensed under the terms of the MIT license.

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,94 @@
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+
+use hex;
+
+pub enum HashAlgorithm {
+    Sha1,
+    Sha256,
+    Blake2b,
+    Blake3,
+    XxHash64,
+    Xxh3,
+    Xxh128,
+}
+
+impl HashAlgorithm {
+    pub fn from_str(name: &str) -> Option<Self> {
+        match name.to_lowercase().as_str() {
+            "sha1" => Some(Self::Sha1),
+            "sha256" => Some(Self::Sha256),
+            "blake2b" => Some(Self::Blake2b),
+            "blake3" => Some(Self::Blake3),
+            "xxhash" | "xxh64" => Some(Self::XxHash64),
+            "xxh3" => Some(Self::Xxh3),
+            "xxh128" => Some(Self::Xxh128),
+            _ => None,
+        }
+    }
+
+    pub fn hash_file(&self, path: &Path) -> io::Result<String> {
+        let mut file = File::open(path)?;
+        match self {
+            Self::Sha1 => {
+                use sha1::{Digest, Sha1};
+                let mut hasher = Sha1::new();
+                stream(&mut file, |buf| hasher.update(buf))?;
+                Ok(format!("{:x}", hasher.finalize()))
+            }
+            Self::Sha256 => {
+                use sha2::{Digest, Sha256};
+                let mut hasher = Sha256::new();
+                stream(&mut file, |buf| hasher.update(buf))?;
+                Ok(format!("{:x}", hasher.finalize()))
+            }
+            Self::Blake2b => {
+                use blake2::{Blake2b512, Digest};
+                let mut hasher = Blake2b512::new();
+                stream(&mut file, |buf| hasher.update(buf))?;
+                Ok(format!("{:x}", hasher.finalize()))
+            }
+            Self::Blake3 => {
+                let mut hasher = blake3::Hasher::new();
+                stream(&mut file, |buf| hasher.update(buf))?;
+                Ok(hasher.finalize().to_hex().to_string())
+            }
+            Self::XxHash64 => {
+                use xxhash_rust::xxh64::Xxh64;
+                let mut hasher = Xxh64::new(0);
+                stream(&mut file, |buf| hasher.update(buf))?;
+                Ok(format!("{:016x}", hasher.digest()))
+            }
+            Self::Xxh3 => {
+                use xxhash_rust::xxh3::Xxh3;
+                let mut hasher = Xxh3::new();
+                stream(&mut file, |buf| hasher.update(buf))?;
+                Ok(format!("{:016x}", hasher.digest()))
+            }
+            Self::Xxh128 => {
+                use xxhash_rust::xxh3::Xxh3;
+                let mut hasher = Xxh3::new();
+                stream(&mut file, |buf| hasher.update(buf))?;
+                let digest = hasher.digest128();
+                Ok(hex::encode(digest))
+            }
+        }
+    }
+}
+
+fn stream<F>(file: &mut File, mut update: F) -> io::Result<()>
+where
+    F: FnMut(&[u8]),
+{
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        update(&buf[..n]);
+    }
+    Ok(())
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,249 @@
+mod hash;
+
+use clap::Parser;
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use hash::HashAlgorithm;
+use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
+
+#[derive(Parser, Debug)]
+#[command(name = "folderhash", about = "Compute and verify file checksums in a directory tree")]
+struct Args {
+    /// Directory to scan
+    #[arg(long)]
+    dir: PathBuf,
+
+    /// File to write or read checksum list
+    #[arg(long)]
+    list: Option<PathBuf>,
+
+    /// Hash algorithm to use (sha1, sha256, blake2b, blake3, xxhash, xxh3, xxh128)
+    #[arg(long, default_value = "sha1")]
+    hash: String,
+
+    /// Verify against a list instead of generating
+    #[arg(long)]
+    verify: bool,
+
+    /// Show progress information
+    #[arg(long)]
+    progress: bool,
+
+    /// Print status of every file when verifying
+    #[arg(long)]
+    verbose: bool,
+
+    /// Use JSONL input/output format
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct HashRecord {
+    hash: String,
+    path: String,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let algo = HashAlgorithm::from_str(&args.hash)
+        .ok_or_else(|| anyhow!("Unsupported hash algorithm: {}", args.hash))?;
+    if args.verify {
+        let list = args
+            .list
+            .ok_or_else(|| anyhow!("--list is required when verifying"))?;
+        verify(&args.dir, &list, algo, args.progress, args.verbose, args.json)?;
+    } else {
+        generate(&args.dir, args.list, algo, args.progress, args.json)?;
+    }
+    Ok(())
+}
+
+fn generate(
+    dir: &Path,
+    list: Option<PathBuf>,
+    algo: HashAlgorithm,
+    progress: bool,
+    json: bool,
+) -> Result<()> {
+    let mut existing = HashSet::new();
+    let mut writer: Box<dyn Write> = match &list {
+        Some(path) => {
+            if path.exists() {
+                let file = File::open(path)?;
+                let reader = BufReader::new(file);
+                if json {
+                    for line in reader.lines() {
+                        let l = line?;
+                        if l.trim().is_empty() {
+                            continue;
+                        }
+                        let rec: HashRecord = serde_json::from_str(&l)?;
+                        existing.insert(rec.path);
+                    }
+                } else {
+                    for line in reader.lines() {
+                        let l = line?;
+                        if l.trim().is_empty() {
+                            continue;
+                        }
+                        if let Some((_, path_part)) = l.split_once(' ') {
+                            existing.insert(path_part.trim().to_string());
+                        }
+                    }
+                }
+            }
+            Box::new(OpenOptions::new().create(true).append(true).open(path)?)
+        }
+        None => Box::new(io::stdout()),
+    };
+
+    let mut count = 0usize;
+    for entry in WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+    {
+        let rel = entry
+            .path()
+            .strip_prefix(dir)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        if existing.contains(&rel) {
+            continue;
+        }
+        let hash = algo
+            .hash_file(entry.path())
+            .with_context(|| format!("hashing {}", rel))?;
+        if json {
+            let rec = HashRecord {
+                hash,
+                path: rel.clone(),
+            };
+            serde_json::to_writer(&mut writer, &rec)?;
+            writeln!(&mut writer)?;
+        } else {
+            writeln!(&mut writer, "{}  {}", hash, rel)?;
+        }
+        count += 1;
+        if progress {
+            eprintln!("processed {}", count);
+        }
+    }
+    Ok(())
+}
+
+fn verify(
+    dir: &Path,
+    list: &Path,
+    algo: HashAlgorithm,
+    progress: bool,
+    verbose: bool,
+    json: bool,
+) -> Result<()> {
+    let file = File::open(list)?;
+    let reader = BufReader::new(file);
+    let mut records: Vec<HashRecord> = Vec::new();
+    if json {
+        for line in reader.lines() {
+            let l = line?;
+            if l.trim().is_empty() {
+                continue;
+            }
+            let rec: HashRecord = serde_json::from_str(&l)?;
+            records.push(rec);
+        }
+    } else {
+        for line in reader.lines() {
+            let l = line?;
+            if l.trim().is_empty() {
+                continue;
+            }
+            if let Some((hash, path_part)) = l.split_once(' ') {
+                records.push(HashRecord {
+                    hash: hash.to_string(),
+                    path: path_part.trim().to_string(),
+                });
+            }
+        }
+    }
+
+    let mut prefix: Option<PathBuf> = None;
+    for rec in &records {
+        let p = PathBuf::from(&rec.path);
+        if p.is_absolute() {
+            prefix = match &prefix {
+                None => Some(p.clone()),
+                Some(prev) => Some(common_prefix(prev, &p)),
+            };
+        } else {
+            prefix = Some(PathBuf::new());
+            break;
+        }
+    }
+    let prefix = prefix.unwrap_or_else(PathBuf::new);
+
+    let total = records.len();
+    let mut mismatches = Vec::new();
+    for (idx, rec) in records.into_iter().enumerate() {
+        let original = PathBuf::from(&rec.path);
+        let rel = original.strip_prefix(&prefix).unwrap_or(&original);
+        let full_path = dir.join(rel);
+        match algo.hash_file(&full_path) {
+            Ok(h) if h == rec.hash => {
+                if verbose {
+                    println!("OK {}", rel.display());
+                }
+            }
+            Ok(h) => {
+                println!(
+                    "MISMATCH {} expected {} got {}",
+                    rel.display(),
+                    rec.hash,
+                    h
+                );
+                mismatches.push(rel.display().to_string());
+            }
+            Err(_) => {
+                println!("MISSING {}", rel.display());
+                mismatches.push(rel.display().to_string());
+            }
+        }
+        if progress {
+            eprintln!("verified {}/{}", idx + 1, total);
+        }
+    }
+
+    if mismatches.is_empty() {
+        if !verbose {
+            println!("All files match");
+        }
+    } else {
+        eprintln!("{} mismatches", mismatches.len());
+    }
+    Ok(())
+}
+
+fn common_prefix(a: &Path, b: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut ita = a.components();
+    let mut itb = b.components();
+    let mut prefix = PathBuf::new();
+    loop {
+        match (ita.next(), itb.next()) {
+            (Some(Component::RootDir), Some(Component::RootDir)) if prefix.as_os_str().is_empty() => {
+                prefix.push(Component::RootDir.as_os_str())
+            }
+            (Some(ca), Some(cb)) if ca == cb => prefix.push(ca.as_os_str()),
+            _ => break,
+        }
+    }
+    prefix
+}
+


### PR DESCRIPTION
## Summary
- introduce a Rust command-line app to compute and verify file checksums across a directory tree
- support multiple algorithms (sha1, sha256, blake2b, blake3, xxhash variants) and JSONL output
- include basic documentation and usage examples

## Testing
- `cargo test` *(failed: failed to download from crates.io - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4e12cfc88328aaabb883e441b62d