### PR TITLE
Add release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build release binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: folderhash-linux-x86_64
+            extension: ""
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: folderhash-linux-aarch64
+            extension: ""
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact: folderhash-macos-x86_64
+            extension: ""
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: folderhash-macos-aarch64
+            extension: ""
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: folderhash-windows-x86_64.exe
+            extension: ".exe"
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            artifact: folderhash-windows-aarch64.exe
+            extension: ".exe"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Prepare artifact
+        run: |
+          mkdir artifacts
+          cp target/${{ matrix.target }}/release/folderhash${{ matrix.extension }} artifacts/${{ matrix.artifact }}
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/${{ matrix.artifact }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build release binaries for Windows, macOS, and Linux on x86_64 and ARM architectures

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68aa52727290832889d425b3031dd9c9