### PR TITLE
Enable xxhash64 and fix hash stream closures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ serde_json = "1"
 sha1 = "0.10"
 sha2 = "0.10"
 walkdir = "2"
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
+xxhash-rust = { version = "0.8", features = ["xxh3", "xxh64"] }
 hex = "0.4"

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -34,44 +34,58 @@ impl HashAlgorithm {
             Self::Sha1 => {
                 use sha1::{Digest, Sha1};
                 let mut hasher = Sha1::new();
-                stream(&mut file, |buf| hasher.update(buf))?;
+                stream(&mut file, |buf| {
+                    hasher.update(buf);
+                })?;
                 Ok(format!("{:x}", hasher.finalize()))
             }
             Self::Sha256 => {
                 use sha2::{Digest, Sha256};
                 let mut hasher = Sha256::new();
-                stream(&mut file, |buf| hasher.update(buf))?;
+                stream(&mut file, |buf| {
+                    hasher.update(buf);
+                })?;
                 Ok(format!("{:x}", hasher.finalize()))
             }
             Self::Blake2b => {
                 use blake2::{Blake2b512, Digest};
                 let mut hasher = Blake2b512::new();
-                stream(&mut file, |buf| hasher.update(buf))?;
+                stream(&mut file, |buf| {
+                    hasher.update(buf);
+                })?;
                 Ok(format!("{:x}", hasher.finalize()))
             }
             Self::Blake3 => {
                 let mut hasher = blake3::Hasher::new();
-                stream(&mut file, |buf| hasher.update(buf))?;
+                stream(&mut file, |buf| {
+                    hasher.update(buf);
+                })?;
                 Ok(hasher.finalize().to_hex().to_string())
             }
             Self::XxHash64 => {
                 use xxhash_rust::xxh64::Xxh64;
                 let mut hasher = Xxh64::new(0);
-                stream(&mut file, |buf| hasher.update(buf))?;
+                stream(&mut file, |buf| {
+                    hasher.update(buf);
+                })?;
                 Ok(format!("{:016x}", hasher.digest()))
             }
             Self::Xxh3 => {
                 use xxhash_rust::xxh3::Xxh3;
                 let mut hasher = Xxh3::new();
-                stream(&mut file, |buf| hasher.update(buf))?;
+                stream(&mut file, |buf| {
+                    hasher.update(buf);
+                })?;
                 Ok(format!("{:016x}", hasher.digest()))
             }
             Self::Xxh128 => {
                 use xxhash_rust::xxh3::Xxh3;
                 let mut hasher = Xxh3::new();
-                stream(&mut file, |buf| hasher.update(buf))?;
+                stream(&mut file, |buf| {
+                    hasher.update(buf);
+                })?;
                 let digest = hasher.digest128();
-                Ok(hex::encode(digest))
+                Ok(hex::encode(digest.to_be_bytes()))
             }
         }
     }


### PR DESCRIPTION
## Summary
- enable xxh64 feature in xxhash-rust
- ensure hashing closures discard return value and encode xxh128 correctly

## Testing
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa548e9f68832888a9fee722eb761e