### PR TITLE
ci: install cross compiler for linux aarch64 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
           override: true
+      - name: Install dependencies
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
       - name: Prepare artifact


### PR DESCRIPTION
## Summary
- install gcc-aarch64-linux-gnu when building the aarch64 linux release

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aa567200648328bf86462568a93430