### PR TITLE
Fix cross-linker for aarch64 Linux builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
## Summary
- specify the `aarch64-linux-gnu-gcc` linker for `aarch64-unknown-linux-gnu` target

## Testing
- `cargo test` *(fails: failed to get `anyhow` as a dependency of package `folderhash v0.1.0 (/workspace/FolderHash)`; failed to download from `https://index.crates.io/config.json`; Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68aaf48a91f08328b4c38c878b72bed1