### PR TITLE
Replace blake2 with blake2b_simd and enable NEON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
-blake2 = { version = "0.10", features = ["simd", "simd_opt"] }
+blake2b_simd = { version = "1", features = ["neon"] }
 blake3 = { version = "1", features = ["neon"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -83,12 +83,13 @@ impl HashAlgorithm {
                 Ok(format!("{:x}", hasher.finalize()))
             }
             Self::Blake2b => {
-                use blake2::{Blake2b512, Digest};
-                let mut hasher = Blake2b512::new();
+                use blake2b_simd::Params;
+                let mut hasher = Params::new().to_state();
                 stream(&mut file, |buf| {
                     hasher.update(buf);
                 })?;
-                Ok(format!("{:x}", hasher.finalize()))
+                let hash = hasher.finalize();
+                Ok(hex::encode(hash.as_bytes()))
             }
             Self::Blake3 => {
                 let mut hasher = blake3::Hasher::new();


### PR DESCRIPTION
## Summary
- switch to the `blake2b_simd` crate with its `neon` feature for BLAKE2b hashing
- update BLAKE2b implementation to use `blake2b_simd`

## Testing
- `cargo build --release --target x86_64-unknown-linux-gnu` *(fails: failed to download crates, 403 response from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1456a04832889811d99dae61980