### PR TITLE
fix: remove unsupported blake2b_simd neon feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
-blake2b_simd = { version = "1", features = ["neon"] }
+blake2b_simd = "1"
 blake3 = { version = "1", features = ["neon"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- remove non-existent `neon` feature from blake2b_simd dependency

## Testing
- `cargo build --release --target x86_64-unknown-linux-gnu` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68ba0790e0f88328a7295853c930fb41