### PR TITLE
Fix RapidHash import

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -248,7 +248,7 @@ impl HashAlgorithm {
                 Ok(hex::encode(bytes))
             },
             Self::RapidHash => {
-                use rapidhash::RapidHasher;
+                use rapidhash::fast::RapidHasher;
                 use std::hash::Hasher;
                 let mut hasher = RapidHasher::default();
                 stream(&mut file, |buf| {


### PR DESCRIPTION
## Summary
- fix rapidhash import to use fast module

## Testing
- `cargo build --offline` *(fails: no matching package named `blake2b_simd` found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0e641a448328b25e0531fd798c10