### PR TITLE
Fix Windows build by disabling SHA assembly features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ blake3 = { version = "1", features = ["neon"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha1 = { version = "0.10", features = ["asm"] }
-sha2 = { version = "0.10", features = ["asm", "asm-aarch64"] }
 walkdir = "2"
 xxhash-rust = { version = "0.8", features = ["xxh3", "xxh64"] }
 hex = "0.4"
@@ -19,3 +17,11 @@ rayon = "1"
 highway = "1.3"
 wyhash = "0.6"
 rapidhash = "4"
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+sha1 = { version = "0.10", features = ["asm"] }
+sha2 = { version = "0.10", features = ["asm", "asm-aarch64"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+sha1 = "0.10"
+sha2 = "0.10"


### PR DESCRIPTION
## Summary
- Disable SHA1/SHA2 assembly features when building on Windows to avoid MSVC assembler errors

## Testing
- `cargo test` *(fails: failed to get `anyhow` as a dependency, download of config.json failed: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68ba13cb29508328837134d89117a378