### PR TITLE
Make gxhash optional to support CPUs without AES/SSE2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,26 +18,32 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact: folderhash-linux-x86_64
             extension: ""
+            rustflags: "-C target-feature=+aes,+sse2"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact: folderhash-linux-aarch64
             extension: ""
+            rustflags: "-C target-feature=+aes,+neon"
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact: folderhash-macos-x86_64
             extension: ""
+            rustflags: "-C target-feature=+aes,+sse2"
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: folderhash-macos-aarch64
             extension: ""
+            rustflags: "-C target-feature=+aes,+neon"
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: folderhash-windows-x86_64.exe
             extension: ".exe"
+            rustflags: "-C target-feature=+aes,+sse2"
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             artifact: folderhash-windows-aarch64.exe
             extension: ".exe"
+            rustflags: "-C target-feature=+aes,+neon"
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
@@ -50,7 +56,9 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --features gxhash --target ${{ matrix.target }}
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
       - name: Prepare artifact
         run: |
           mkdir artifacts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,16 @@ rayon = "1"
 highway = "1.3"
 wyhash = "0.6"
 rapidhash = "4"
-gxhash = "3.5.0"
+gxhash = { version = "3.5.0", optional = true }
 t1ha = "0.1.2"
 sha3 = "0.10"
 k12 = "0.3"
 md-5 = "0.10"
 crc = "3"
+
+[features]
+default = []
+gxhash = ["dep:gxhash"]
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 sha1 = { version = "0.10", features = ["asm"] }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,17 @@ previously generated checksum list.
 By default the program uses the SHA1 hash algorithm but the algorithm can be
 changed using the `--hash` flag. Supported values include `sha1`, `sha256`,
 `sha512`, `sha3`, `blake2b`, `blake3`, `md5`, `xxhash`, `xxh3`, `xxh128`,
-`wyhash`, `gxhash`, `t1ha1`, `t1ha2`, `k12`, `highway64`, `highway128`,
+`wyhash`, `t1ha1`, `t1ha2`, `k12`, `highway64`, `highway128`,
 `highway256`, `rapidhash`, `crc32` and `crc64`.
+
+The `gxhash` algorithm is available behind an optional Cargo feature because it
+requires `aes` and `sse2` CPU intrinsics. Enable it during compilation with:
+
+```
+cargo build --features gxhash
+```
+
+After enabling the feature, `gxhash` can be selected with `--hash gxhash`.
 
 ## SIMD acceleration
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -41,6 +41,7 @@ pub enum HashAlgorithm {
     Xxh3,
     Xxh128,
     Wyhash,
+    #[cfg(feature = "gxhash")]
     GxHash,
     T1ha1,
     T1ha2,
@@ -67,6 +68,7 @@ impl HashAlgorithm {
             "xxh3" => Some(Self::Xxh3),
             "xxh128" => Some(Self::Xxh128),
             "wyhash" => Some(Self::Wyhash),
+            #[cfg(feature = "gxhash")]
             "gxhash" => Some(Self::GxHash),
             "t1ha1" => Some(Self::T1ha1),
             "t1ha2" => Some(Self::T1ha2),
@@ -255,6 +257,7 @@ impl HashAlgorithm {
                 })?;
                 Ok(format!("{:016x}", hasher.finish()))
             }
+            #[cfg(feature = "gxhash")]
             Self::GxHash => {
                 use gxhash::GxHasher;
                 use std::hash::Hasher;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,14 @@ struct Args {
     #[arg(long)]
     list: Option<PathBuf>,
 
-    /// Hash algorithm to use (sha1, sha256, sha512, sha3, blake2b, blake3, md5, xxhash, xxh3, xxh128, wyhash, gxhash, t1ha1, t1ha2, k12, highway64, highway128, highway256, rapidhash, crc32, crc64)
+    #[cfg_attr(
+        feature = "gxhash",
+        doc = "Hash algorithm to use (sha1, sha256, sha512, sha3, blake2b, blake3, md5, xxhash, xxh3, xxh128, wyhash, gxhash, t1ha1, t1ha2, k12, highway64, highway128, highway256, rapidhash, crc32, crc64)"
+    )]
+    #[cfg_attr(
+        not(feature = "gxhash"),
+        doc = "Hash algorithm to use (sha1, sha256, sha512, sha3, blake2b, blake3, md5, xxhash, xxh3, xxh128, wyhash, t1ha1, t1ha2, k12, highway64, highway128, highway256, rapidhash, crc32, crc64)"
+    )]
     #[arg(long, default_value = "sha1")]
     hash: String,
 


### PR DESCRIPTION
## Summary
- make the gxhash dependency optional and gate related code
- document how to enable gxhash and its CPU requirements
- build release binaries with the `gxhash` feature and proper target flags

## Testing
- `cargo test --locked` *(fails: command not found: cargo; `apt-get update` 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bac6d44b4883288f85015d6dbb8bc2